### PR TITLE
Using an explicit configuration file instead of relying on Environmen…

### DIFF
--- a/api.config.cfg
+++ b/api.config.cfg
@@ -1,0 +1,15 @@
+DEBUG=False
+
+# Metadata flatfile location
+METADATA_FILE="data/FFMetadata20180221.csv"
+
+# Database credentials. The following are just placeholders - replace with real credentials.
+AWS_RDS_USER="db_user"
+AWS_RDS_PASS="db_password"
+AWS_RDS_ENDPOINT="db_hostname"
+AWS_RDS_PORT=3306
+DB_NAME="db_name"
+
+# SQLAlchemy settings
+SQLALCHEMY_DATABASE_URI = "mysql+pymysql://{}:{}@{}:{}/{}".format(AWS_RDS_USER, AWS_RDS_PASS, AWS_RDS_ENDPOINT, AWS_RDS_PORT, DB_NAME)
+SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/webMetadataAPI.py
+++ b/webMetadataAPI.py
@@ -16,7 +16,7 @@ from sqlalchemy import or_
 application = Flask(__name__)
 
 # Configure application
-application.config.from_envvar('APP_CONFIG', silent=True)
+application.config.from_pyfile('api.config.cfg')
 db = SQLAlchemy(application)
 
 


### PR DESCRIPTION
Using an explicit configuration file instead of relying on Environment Variables. A sample configuration file included with redacted credentials for the database. This will make it easier to port the application from server to server without mysterious error messages.